### PR TITLE
feat: Add rustls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 serde = { version = "1.0.217", features = ["derive"] }
 strum_macros = "0.26.4"
 serde_json = "1.0.135"
-reqwest = { version="0.12.12", features = ["json", "blocking"]  }
+reqwest = { version="0.12.12", features = ["json", "blocking"], default-features = false }
 strum = "0.26.3"
 tokio = { version = "1.43.0", features = ["full"]  }
 isocountry = "0.3.2"
@@ -27,4 +27,7 @@ futures = "0.3.31"
 dotenv = "0.15.0"
 
 [features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 blocking = []

--- a/src/endpoints/api.rs
+++ b/src/endpoints/api.rs
@@ -23,6 +23,9 @@ impl GooglePlacesAPI {
             api_key: String::from(
                 key,
             ),
+            #[cfg(feature = "rustls-tls")]
+            client: Client::builder().use_rustls_tls().build().unwrap(),
+            #[cfg(not(feature = "rustls-tls"))]
             client: Client::new(),
         }
     }
@@ -33,6 +36,9 @@ impl GooglePlacesAPI {
             api_key: String::from(
                 std::env::var("GOOGLE_PLACES_API_KEY").expect("GOOGLE_PLACES_API_KEY must be set."),
             ),
+            #[cfg(feature = "rustls-tls")]
+            client: Client::builder().use_rustls_tls().build().unwrap(),
+            #[cfg(not(feature = "rustls-tls"))]
             client: Client::new(),
         }
     }


### PR DESCRIPTION
## Summary

Adds optional rustls support, allowing the crate to be used in environments where openssl is not desirable.
  
## Description

This change introduces a rustls-tls feature flag to enable reqwest's rustls backend. The existing native-tls feature is set as the default to ensure backward compatibility.

This provides flexibility for developers, especially when creating static MUSL builds, by allowing them to opt out of the openssl dependency.

To use rustls, update your `Cargo.toml` as follows:

```toml
[dependencies]
google-places-api = { version = "...", default-features = false, features = ["rustls-tls"] }
```

## Proof of Testing

- [x] Manual testing completed
- [ ] Unit tests completed
- [ ] Integration tests completed

## Type of Change

<!-- Check the box that best describes this PR -->

- [ ] Breaking Features
- [ ] Breaking Fixes
- [x] Backwards Compatible Features
- [ ] Backwards Compatible Fixes
- [ ] Under the Hood (Refactoring, etc.)
- [ ] Documentation
- [ ] Dependencies

## Additional Notes

None
